### PR TITLE
github: bump actions to node20

### DIFF
--- a/.github/workflows/trigger.yml
+++ b/.github/workflows/trigger.yml
@@ -18,7 +18,7 @@ jobs:
     name: L4v
     runs-on: ubuntu-latest
     steps:
-      - uses: peter-evans/repository-dispatch@v2
+      - uses: peter-evans/repository-dispatch@v3
         if: ${{ github.event.pusher.login != 'seL4-ci' }}
         with:
           token: ${{ secrets.PRIV_REPO_TOKEN }}


### PR DESCRIPTION
GitHub has started issuing warnings for node16 actions.